### PR TITLE
build(gh-pages): create workflow for automatic MD file conversion on push

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+name: gh-pages
+on:
+  push:
+    paths:
+      - '**.md'  
+  workflow_dispatch:
+        
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npx markdown-to-html-cli -y 
+
+      - uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            BRANCH: gh-pages
+            FOLDER: "."
+            CLEAN: false

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,8 +1,10 @@
 name: gh-pages
 on:
   push:
+    branches:
+      - master
     paths:
-      - '**.md'  
+      - 'README.md'  
   workflow_dispatch:
         
 jobs:


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automatically converts Markdown files to HTML whenever changes are pushed to the repository. The workflow is triggered by changes to any `.md` file and utilizes the `markdown-to-html-cli` package to perform the conversion. The converted files are then deployed to the `gh-pages` branch using the `JamesIves/github-pages-deploy-action`.