### PR TITLE
feat(github-actions): add upstream sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,48 @@
+name: Upstream Sync
+
+permissions:
+  contents: write
+  issues: write
+  actions: write
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # every 6 hours
+  workflow_dispatch:
+
+jobs:
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clean issue notice
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          labels: '🚨 Sync Fail'
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+        with:
+          upstream_sync_repo: tnfe/TNT-Weekly
+          upstream_sync_branch: master
+          target_sync_branch: master
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }} # automatically generated, no need to set
+          test_mode: false
+
+      - name: Sync check
+        if: failure()
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-issue'
+          title: '🚨 同步失败 | Sync Fail'
+          labels: '🚨 Sync Fail'
+          body: |
+            Due to a change in the workflow file of the [TNT-Weekly][TNT-Weekly] upstream repository, GitHub has automatically suspended the scheduled automatic update. You need to manually sync your fork。
+
+            由于 [TNT-Weekly][TNT-Weekly] 上游仓库的 workflow 文件变更，导致 GitHub 自动暂停了本次自动更新，你需要手动 Sync Fork 一次。


### PR DESCRIPTION
Add a new GitHub Actions workflow that automates the synchronization of a forked repository with the upstream master branch every 6 hours. This ensures that the fork remains up-to-date with the latest changes from the upstream repo.

The workflow includes steps for cleaning up any existing issue notices and for reporting synchronization failures through GitHub issues.

BREAKING CHANGE: This change introduces a new workflow that requires write permissions to the repository. Ensure that the necessary permissions are set before enabling the workflow.